### PR TITLE
Fix pyttsx3 COM handling

### DIFF
--- a/worlds/poe/poeClient/tts.py
+++ b/worlds/poe/poeClient/tts.py
@@ -20,10 +20,11 @@ def safe_tts(text, filename, rate=250, volume=1, voice_id=None, overwrite=False)
     Path(filename).parent.mkdir(parents=True, exist_ok=True)
     try:
         import pyttsx3
-#        engine = pyttsx3.init()
         engine = None
         if sys.platform.startswith('win'):
-            engine = pyttsx3.init('sapi5')  # Use SAPI5 for Windows
+            import pythoncom
+            pythoncom.CoInitialize()
+            engine = pyttsx3.Engine('sapi5')
         else:
             engine = pyttsx3.init()
         if _debug:
@@ -37,6 +38,9 @@ def safe_tts(text, filename, rate=250, volume=1, voice_id=None, overwrite=False)
             print("[DEBUG] Voices available:", voices)
         engine.save_to_file(text, str(filename))
         engine.runAndWait()
+        engine.stop()
+        if sys.platform.startswith('win'):
+            pythoncom.CoUninitialize()
         if Path(filename).exists():
             print(f"[DEBUG] File created: {filename}")
         else:
@@ -49,13 +53,15 @@ def tts_blocking(text, filename, rate=250, volume=1, voice_id=None):
     pythoncom.CoInitialize()
     import pyttsx3
     Path(filename).parent.mkdir(parents=True, exist_ok=True)
-    engine = pyttsx3.init('sapi5')
+    engine = pyttsx3.Engine('sapi5')
     engine.setProperty('rate', rate)
     engine.setProperty('volume', volume)
     if voice_id is not None:
         engine.setProperty('voice', voice_id)
     engine.save_to_file(text, str(filename))
     engine.runAndWait()
+    engine.stop()
+    pythoncom.CoUninitialize()
 
 
 async def safe_tts_async(text, filename, rate=250, volume=1, voice_id=None):


### PR DESCRIPTION
## Summary
- adjust Path of Exile TTS to create the SAPI5 engine directly
- ensure COM is initialized and shut down cleanly

## Testing
- `pytest -q` *(fails: 621 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687f13df67f48330b8c474a7286dec11