### PR TITLE
Fix Path of Exile act 10 generation

### DIFF
--- a/worlds/poe/Items.py
+++ b/worlds/poe/Items.py
@@ -99,7 +99,8 @@ def deprioritize_non_logic_gear(world: "PathOfExileWorld", table: Dict[int, Item
 
 
     gear_ids = [item["id"] for item in get_gear_items(table)]
-    progression_gear_ids = world.random.sample(gear_ids, opt.gear_upgrades_per_act.value * world.goal_act)
+    progression_sample_size = min(opt.gear_upgrades_per_act.value * world.goal_act, len(gear_ids))
+    progression_gear_ids = world.random.sample(gear_ids, progression_sample_size)
 
     for item in [ item for item in get_gear_items()]:
         if item["name"] in required_weps or item["id"] in progression_gear_ids:


### PR DESCRIPTION
## Summary
- avoid oversampling gear upgrades when creating Path of Exile item pool

## Testing
- `pytest test -q` *(fails: test_general/test_items.py, test_general/test_locations.py, test_general/test_packages.py, test/webhost/test_docs.py)*

------
https://chatgpt.com/codex/tasks/task_e_688c5d1eec148330b796a82d772954fc